### PR TITLE
Solve ESLint issues

### DIFF
--- a/src/books.js
+++ b/src/books.js
@@ -14,13 +14,16 @@ const BookDetails = () => {
 
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(async () => {
-    setIsLoading(true);
-    const resources = await axios.get(
-      `https://www.googleapis.com/books/v1/volumes?q=${term}&maxResults=11`
-    );
-    setDetails(resources.data.items);
-    setIsLoading(false);
+  useEffect(() => {
+    const fetchDetails = async () => {
+      setIsLoading(true);
+      const resources = await axios.get(
+        `https://www.googleapis.com/books/v1/volumes?q=${term}&maxResults=11`
+      );
+      setDetails(resources.data.items);
+      setIsLoading(false);
+    }
+    fetchDetails();
   }, [term]);
 
   const loadMore = async () => {
@@ -84,7 +87,7 @@ const BookDetails = () => {
               <img
                 style={{ width: "100%" }}
                 src={logo}
-                alt="Books-Image"
+                alt="A man reading a book"
                 srcset=""
               />
 


### PR DESCRIPTION
#### Describe the changes you've made
Resolved the ESLint issues that were appearing after executing `npm start`. These warnings were appearing every time the command was executed.
Previous behaviour after executing `npm start`:
```
Compiled with warnings.

src/books.js
  Line 17:13:  Effect callbacks are synchronous to prevent race conditions. Put the async function inside:

useEffect(() => {
  async function fetchData() {
    // You can await here
    const response = await MyAPI.getData(someId);
    // ...
  }
  fetchData();
}, [someId]); // Or [] if effect doesn't need props or state

Learn more about data fetching with Hooks: https://reactjs.org/link/hooks-data-fetching  react-hooks/exhaustive-deps
  Line 84:15:  Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop                                                                                                                                                                                                                jsx-a11y/img-redundant-alt

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.
```
New behaviour:
```
Compiled successfully!

You can now view bookery-using-reactjs in the browser.

  Local:            http://localhost:3000
  On Your Network:  http://192.168.1.39:3000

Note that the development build is not optimized.
To create a production build, use npm run build.
```

## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Removes warnings when starting the app


## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

